### PR TITLE
[don't merge] async experiment

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,7 @@
   :license {:name "Apache Version 2.0"
             :url "https://www.apache.org/licenses/LICENSE-2.0"}
   :dependencies [[org.clojure/clojure "1.9.0"]
+                 [org.clojure/core.async "0.4.474"]
                  [aleph "0.4.4"]
                  [io.netty/netty-tcnative-boringssl-static "2.0.0.Final"]
                  [io.netty/netty-all "4.1.11.Final"]

--- a/src/borda_clj/client.clj
+++ b/src/borda_clj/client.clj
@@ -17,11 +17,11 @@
         (do (print "borda buffer full, discarding measurement" dimensions values)
             measurements))))) ; buffer full
 
-(defn go-reduce-reports [in-ch out-ch kill-ch max-buffer-size]
+(defn go-reduce-reports [report-ch measurements-ch kill-ch max-buffer-size]
   (go-loop [measurements {}]
-    (let [[v ch] (alts! [in-ch [out-ch measurements]])]
+    (let [[v ch] (alts! [report-ch [measurements-ch measurements]])]
       (cond
-        (= ch out-ch) (recur {})
+        (= ch measurements-ch) (recur {})
         (nil? v) (close! kill-ch)
         :else (recur (apply collect measurements max-buffer-size v))))))
 


### PR DESCRIPTION
I had a hunch that the logic in `reducing-submitter` might be more naturally expressed with core.async.  Since I hadn't done anything substantial with this library yet I decided to give it a try.  My first shot at it is not any shorter than the original version, but I thought that coming from Golang you may find it interesting.  I have some refactoring plans for this and if they transpire I might submit a serious PR.